### PR TITLE
Pass inode to current_time

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -50,7 +50,7 @@ static int sfs_mknod(struct inode *dir, struct dentry *dentry,
 		d_instantiate(dentry, inode);
 		dget(dentry);   /* Extra count - pin the dentry in core */
 		error = 0;
-		dir->i_mtime = dir->i_ctime = current_time();
+		dir->i_mtime = dir->i_ctime = current_time(inode);
 
 		/* real filesystems would normally use i_size_write function */
 		dir->i_size += 0x20;  /* bogus small size for each dir entry */
@@ -93,7 +93,7 @@ static int sfs_symlink(struct inode * dir, struct dentry *dentry,
 				inode->i_gid = dir->i_gid;
 			d_instantiate(dentry, inode);
 			dget(dentry);
-			dir->i_mtime = dir->i_ctime = current_time();
+			dir->i_mtime = dir->i_ctime = current_time(inode);
 		} else
 			iput(inode);
 	}

--- a/super.c
+++ b/super.c
@@ -73,7 +73,7 @@ struct inode *samplefs_get_inode(struct super_block *sb,
 		inode->i_ino = get_next_ino();
 		inode_init_owner(inode, dir, mode);
 		inode->i_blocks = 0;
-		inode->i_atime = inode->i_mtime = inode->i_ctime = current_time();
+		inode->i_atime = inode->i_mtime = inode->i_ctime = current_time(inode);
 		inode->i_mapping->a_ops = &sfs_aops;
 		mapping_set_gfp_mask(inode->i_mapping, GFP_HIGHUSER);
 		mapping_set_unevictable(inode->i_mapping);


### PR DESCRIPTION
The current_time function signature is changed since 4.8-rc6.

Signed-off-by: Santosh Sivaraj <santosh@fossix.org>